### PR TITLE
xlocale.h -> bits/types/__locale_t.h

### DIFF
--- a/src/librexgen/string/simplestring.h
+++ b/src/librexgen/string/simplestring.h
@@ -26,7 +26,7 @@
 #include <librexgen/osdepend.h>
 #include <string.h>
 #include <stdlib.h>
-#include <xlocale.h>
+#include <bits/types/__locale_t.h>
 #include <string>
 #include <algorithm>
 #include <cassert>

--- a/src/librexgen/string/simplestring.h
+++ b/src/librexgen/string/simplestring.h
@@ -26,8 +26,13 @@
 #include <librexgen/osdepend.h>
 #include <string.h>
 #include <stdlib.h>
+#include <features.h>
+#ifdef __GLIBC__
 #include <bits/types/__locale_t.h>
 #include <string>
+#else
+#include <xlocale.h>
+#endif
 #include <algorithm>
 #include <cassert>
 #include <cwctype>

--- a/src/librexgen/string/simplestring.h
+++ b/src/librexgen/string/simplestring.h
@@ -29,10 +29,10 @@
 #include <features.h>
 #ifdef __GLIBC__
 #include <bits/types/__locale_t.h>
-#include <string>
 #else
 #include <xlocale.h>
 #endif
+#include <string>
 #include <algorithm>
 #include <cassert>
 #include <cwctype>


### PR DESCRIPTION
in the new glibc xlocale.h is named bits/types/__locale_t.h:
https://sourceware.org/git/?p=glibc.git;a=commit;h=f0be25b6336db7492e47d2e8e72eb8af53b5506d